### PR TITLE
sentry sdk fixed

### DIFF
--- a/mumblebackend/settings.py
+++ b/mumblebackend/settings.py
@@ -20,19 +20,20 @@ import django_heroku
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
-sentry_sdk.init(
-    dsn="https://de808f6f605c4fd79120ddb21f073904@o599875.ingest.sentry.io/5743882",
-    integrations=[DjangoIntegration()],
+if os.getcwd() == '/app':
+    sentry_sdk.init(
+        dsn="https://de808f6f605c4fd79120ddb21f073904@o599875.ingest.sentry.io/5743882",
+        integrations=[DjangoIntegration()],
 
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    # We recommend adjusting this value in production.
-    traces_sample_rate=1.0,
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        # We recommend adjusting this value in production.
+        traces_sample_rate=1.0,
 
-    # If you wish to associate users to errors (assuming you are using
-    # django.contrib.auth) you may enable sending PII data.
-    send_default_pii=True
-)
+        # If you wish to associate users to errors (assuming you are using
+        # django.contrib.auth) you may enable sending PII data.
+        send_default_pii=True
+    )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION

### Describe your changes :

I changed the sentry SDK to send error notifications only when it is deployed to Heroku! 
because local errors while development were also been sent to the Sentry dashboard

<!-- Explain what you have done !-->
Just added if condition to check if the API is on local or on Heroku 