### PR TITLE
161 - adding the ability to update a profile interests or skills

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -19,7 +19,7 @@ class SkillTagSerializer(serializers.ModelSerializer):
 class UserProfileSerializer(serializers.ModelSerializer):
     profile_pic = serializers.SerializerMethodField(read_only=True)
     interests = TopicTagSerializer(many=True, read_only=True)
-    skills = SkillTagSerializer(many=True, read_only=True)
+    skills = SkillTagSerializer(many=True, read_only=False)
     class Meta:
         model = UserProfile
         fields = '__all__'

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -19,7 +19,7 @@ class SkillTagSerializer(serializers.ModelSerializer):
 class UserProfileSerializer(serializers.ModelSerializer):
     profile_pic = serializers.SerializerMethodField(read_only=True)
     interests = TopicTagSerializer(many=True, read_only=True)
-    skills = SkillTagSerializer(many=True, read_only=False)
+    skills = SkillTagSerializer(many=True, read_only=True)
     class Meta:
         model = UserProfile
         fields = '__all__'

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -7,6 +7,8 @@ from rest_framework.test import APITestCase
 import json
 # Create your tests here.
 
+from ..models import SkillTag, TopicTag
+
 from users.views import email_validator
 
 class AccountTests(APITestCase):
@@ -131,4 +133,34 @@ class AccountTests(APITestCase):
         client = APIClient()
         client.force_authenticate(user=self.test_user)
         response = client.post(reversed_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+    def test_update_skills(self):
+        url = 'users-api:update_skills'
+        reversed_url = reverse(url)
+        client = APIClient()
+        client.force_authenticate(user=self.test_user)
+        response = client.patch(reversed_url, [
+            {'name': 'javascript'}
+        ])
+        response_json = json.loads(response.content)
+        tag = SkillTag.objects.get(name='javascript')
+        self.assertEqual(tag.name, 'javascript')
+        self.assertEqual(response_json['skills'], [{'name': 'javascript'}])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+    def test_update_interests(self):
+        url = 'users-api:update_interests'
+        reversed_url = reverse(url)
+        client = APIClient()
+        client.force_authenticate(user=self.test_user)
+        response = client.patch(reversed_url, [
+            {'name': 'agile'}
+        ])
+        response_json = json.loads(response.content)
+        tag = TopicTag.objects.get(name='agile')
+        self.assertEqual(tag.name, 'agile')
+        self.assertEqual(response_json['interests'], [{'name': 'agile'}])
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/users/urls.py
+++ b/users/urls.py
@@ -20,8 +20,8 @@ urlpatterns = [
     path('refresh_token/', TokenRefreshView.as_view(), name='refresh_token'),
 
     path('profile_update/', views.UserProfileUpdate.as_view(), name="profile_update"), 
-    path('profile_update/skills/', views.updateSkills, name='update_skills'),
-    path('profile_update/interests/', views.updateInterests, name='update_interests'),
+    path('profile_update/skills/', views.update_skills, name='update_skills'),
+    path('profile_update/interests/', views.update_interests, name='update_interests'),
     path('profile_update/photo/', views.ProfilePictureUpdate.as_view(), name="profile_update_photo"), 
     path('<str:username>/follow/', views.followUser, name="follow-user"),
 

--- a/users/urls.py
+++ b/users/urls.py
@@ -20,6 +20,8 @@ urlpatterns = [
     path('refresh_token/', TokenRefreshView.as_view(), name='refresh_token'),
 
     path('profile_update/', views.UserProfileUpdate.as_view(), name="profile_update"), 
+    path('profile_update/skills/', views.updateSkills, name='update_skills'),
+    path('profile_update/interests/', views.updateInterests, name='update_interests'),
     path('profile_update/photo/', views.ProfilePictureUpdate.as_view(), name="profile_update_photo"), 
     path('<str:username>/follow/', views.followUser, name="follow-user"),
 

--- a/users/views.py
+++ b/users/views.py
@@ -177,7 +177,7 @@ def profile(request):
 
 @api_view(['PATCH'])
 @permission_classes((IsAuthenticated,))
-def updateSkills(request): 
+def update_skills(request): 
     user_profile = request.user.userprofile
     skills = request.data
     to_set = []
@@ -194,7 +194,7 @@ def updateSkills(request):
 
 @api_view(['PATCH'])
 @permission_classes((IsAuthenticated,))
-def updateInterests(request): 
+def update_interests(request): 
     user_profile = request.user.userprofile
     interests = request.data
     to_set = []

--- a/users/views.py
+++ b/users/views.py
@@ -30,7 +30,7 @@ from feed.serializers import MumbleSerializer
 from notification.models import Notification
 from notification.serializers import NotificationSerializer
 
-from .models import UserProfile
+from .models import UserProfile, SkillTag, TopicTag
 from .serializers import (UserProfileSerializer, UserSerializer,
                           UserSerializerWithToken, CurrentUserSerializer)
 
@@ -173,6 +173,40 @@ def following(request):
 def profile(request):
     user = request.user
     serializer = UserSerializer(user, many=False)
+    return Response(serializer.data)
+
+@api_view(['PATCH'])
+@permission_classes((IsAuthenticated,))
+def updateSkills(request): 
+    user_profile = request.user.userprofile
+    skills = request.data
+    to_set = []
+    for skill in skills:
+        try:
+            s = SkillTag.objects.get_or_create(name=skill['name'])[0]
+            to_set.append(s)
+        except Exception as e:
+            pass
+    user_profile.skills.set(to_set)
+    user_profile.save()
+    serializer = UserProfileSerializer(user_profile, many=False)
+    return Response(serializer.data)
+
+@api_view(['PATCH'])
+@permission_classes((IsAuthenticated,))
+def updateInterests(request): 
+    user_profile = request.user.userprofile
+    interests = request.data
+    to_set = []
+    for interest in interests:
+        try:
+            interest = TopicTag.objects.get_or_create(name=interest['name'])[0]
+            to_set.append(interest)
+        except Exception as e:
+            pass
+    user_profile.interests.set(to_set)
+    user_profile.save()
+    serializer = UserProfileSerializer(user_profile, many=False)
     return Response(serializer.data)
 
 @api_view(['POST'])

--- a/users/views.py
+++ b/users/views.py
@@ -180,14 +180,9 @@ def profile(request):
 def update_skills(request): 
     user_profile = request.user.userprofile
     skills = request.data
-    to_set = []
-    for skill in skills:
-        try:
-            s = SkillTag.objects.get_or_create(name=skill['name'])[0]
-            to_set.append(s)
-        except Exception as e:
-            pass
-    user_profile.skills.set(to_set)
+    user_profile.skills.set(
+        SkillTag.objects.get_or_create(name=skill['name'])[0] for skill in skills
+    )
     user_profile.save()
     serializer = UserProfileSerializer(user_profile, many=False)
     return Response(serializer.data)
@@ -197,14 +192,9 @@ def update_skills(request):
 def update_interests(request): 
     user_profile = request.user.userprofile
     interests = request.data
-    to_set = []
-    for interest in interests:
-        try:
-            interest = TopicTag.objects.get_or_create(name=interest['name'])[0]
-            to_set.append(interest)
-        except Exception as e:
-            pass
-    user_profile.interests.set(to_set)
+    user_profile.interests.set(
+        TopicTag.objects.get_or_create(name=interest['name'])[0] for interest in interests
+    )
     user_profile.save()
     serializer = UserProfileSerializer(user_profile, many=False)
     return Response(serializer.data)


### PR DESCRIPTION
#161 

### Describe your changes :

Added two endpoints that we can do PATCH requests for setting the new skills or interests on a user profile.

`PATCH@/api/users/profile_update/skills/` using payload of `[{name: 'javascript'}]`
`PATCH@/api/users/profile_update/interests/` using payload of `[{name: 'javascript'}]`

#

### Type of change :

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Checklist:

- [x] I have read the **Code Of Conduct** document.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.


